### PR TITLE
add image fit parameter

### DIFF
--- a/lib/f_glitch.dart
+++ b/lib/f_glitch.dart
@@ -10,6 +10,7 @@ class FGlitch extends StatefulWidget {
   FGlitch(
       {Key? key,
       required this.imageProvider,
+      this.imageFit,
       this.frequency = 1000,
       this.glitchRate = 50,
       List<Color> channelColors = const [],
@@ -33,6 +34,9 @@ class FGlitch extends StatefulWidget {
 
   /// A image that is used to effected.
   final ImageProvider imageProvider;
+
+  // How to fit the image during layout.
+  final BoxFit? imageFit;
 
   late final List<_ColorChannel> _colorChannels;
   late final List<_GlitchMask> _glitchList;
@@ -187,6 +191,7 @@ class _FGlitchState extends State<FGlitch> {
         blendMode: BlendMode.plus,
         child: Image(
           image: widget.imageProvider,
+          fit: widget.imageFit,
           color: cc._color,
           colorBlendMode: BlendMode.multiply,
         ),
@@ -206,6 +211,7 @@ class _FGlitchState extends State<FGlitch> {
               children: [
                 Image(
                   image: widget.imageProvider,
+                  fit: widget.imageFit,
                   color: Colors.white,
                   colorBlendMode: g._blendMode,
                 ),


### PR DESCRIPTION
Adds an optional image fit parameter to pass through to the `Image`.

Example, without the fit set to `BoxFit.cover` (current behaviour) :

<img width="382" alt="" src="https://user-images.githubusercontent.com/816965/185728643-93e24e79-0080-4bcc-8b0f-95589890a1d7.png">

Example, with the fit set to `BoxFit.cover` by using the new `imageFit` parameter:

<img width="382" alt="" src="https://user-images.githubusercontent.com/816965/185728631-65b35eac-e044-4a42-819d-0275c4d7a1e5.png">



